### PR TITLE
Started breaking the command shell dependencies in file.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ keys/*
 *.key
 *.private
 *.tmproj
+
+#Scott
+.gitignore
+.idea/*
+*.iml


### PR DESCRIPTION
file.rb relied heavily on the `shell command` processes. Brought in FileUtils and dir to help break that dependency which also helped clean up the code. Moved @stagedirectory to an attr_accessor :stage_directory. Left splitfile alone but I strongly suggest finding a programmatic way of doing it; one example can be found here http://stackoverflow.com/questions/6150227/ruby-how-to-split-a-file-into-multiple-files-of-a-given-size.

Left uuencode, numberfiles & stage alone for now. Also, I am not sure how cleanfile will work if randomname changes each time it is called. Likely not to find a new file name unless I am missing something. Just converted to the FileUtils call for the moment.

.gitignore got update with my changes... not sure you really wanted that and I tried to get git to ignore it.
